### PR TITLE
Bump qttabbar version to 1040.

### DIFF
--- a/qttabbar.json
+++ b/qttabbar.json
@@ -1,6 +1,6 @@
 {
-    "version": "1038",
-    "url": "http://qttabbar.wdfiles.com/local--files/qttabbar/QTTabBar_1038.zip",
+    "version": "1040",
+    "url": "http://qttabbar.wdfiles.com/local--files/qttabbar/UpdateQTTabBar1040.zip",
     "installer": {"file": "QTTabBar.exe", "args": "/qi", "keep": "true"},
     "uninstaller": {"file": "QTTabBar.exe", "args": "/qu"}
 }


### PR DESCRIPTION
So 1040 is an update to be installed over 1038, not a standalone. Not sure what the best way to handle installing both packages is.